### PR TITLE
profit_loss now decreases vault_total_shares & events additions

### DIFF
--- a/programs/tokenized_vault/src/events.rs
+++ b/programs/tokenized_vault/src/events.rs
@@ -79,6 +79,7 @@ pub struct VaultWithdrawlEvent {
 pub struct VaultUpdateDepositLimitEvent {
     pub vault_key: Pubkey, 
     pub new_limit: u64,
+    pub timestamp: i64,
 }
 
 #[event]
@@ -98,6 +99,7 @@ pub struct UpdatedCurrentDebtForStrategyEvent {
 
 #[event]
 pub struct StrategyReportedEvent {
+    pub vault_key: Pubkey,
     pub strategy_key: Pubkey,
     pub gain: u64,
     pub loss: u64,
@@ -125,6 +127,7 @@ pub struct WithdrawalRequestedEvent {
     pub max_loss: u64,
     pub fee_shares: u64,
     pub index: u64,
+    pub timestamp: i64,
 }
 
 #[event]
@@ -132,6 +135,7 @@ pub struct WithdrawalRequestCanceledEvent {
     pub user: Pubkey,
     pub vault: Pubkey,
     pub index: u64,
+    pub timestamp: i64,
 }
 
 #[event]
@@ -140,4 +144,61 @@ pub struct WithdrawalRequestFulfilledEvent {
     pub vault: Pubkey,
     pub amount: u64,
     pub index: u64,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultUpdateMinUserDepositEvent {
+    pub vault_key: Pubkey,
+    pub new_min_user_deposit: u64,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultUpdateProfitMaxUnlockTimeEvent {
+    pub vault_key: Pubkey,
+    pub new_profit_max_unlock_time: u64,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultUpdateMinTotalIdleEvent {
+    pub vault_key: Pubkey,
+    pub new_min_total_idle: u64,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultUpdateDirectWithdrawEnabledEvent {
+    pub vault_key: Pubkey,
+    pub new_direct_withdraw_enabled: bool,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultUpdateUserDepositLimitEvent {
+    pub vault_key: Pubkey,
+    pub new_user_deposit_limit: u64,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultUpdateAccountantEvent {
+    pub vault_key: Pubkey,
+    pub new_accountant: Pubkey,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultUpdateWhitelistedOnlyEvent {
+    pub vault_key: Pubkey,
+    pub new_whitelisted_only: bool,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultRemoveStrategyEvent {
+    pub vault_key: Pubkey,
+    pub strategy_key: Pubkey,
+    pub removed_at: i64,
 }

--- a/programs/tokenized_vault/src/instructions/reporting/process_report.rs
+++ b/programs/tokenized_vault/src/instructions/reporting/process_report.rs
@@ -103,6 +103,7 @@ pub fn handle_process_report(ctx: Context<ProcessReport>) -> Result<()> {
     msg!("share_price: {}", share_price);
 
     emit!(StrategyReportedEvent {
+        vault_key: ctx.accounts.vault.key(),
         strategy_key: strategy.key(),
         gain: profit,
         loss,
@@ -204,6 +205,7 @@ fn handle_loss(ctx: &Context<ProcessReport>, loss: u64) -> Result<()> {
     let vault = &mut ctx.accounts.vault.load_mut()?;
     vault.total_debt -= loss;
     vault.last_profit_update = get_timestamp()?;
+    vault.total_shares -= shares_to_burn;
 
     Ok(())
 }

--- a/programs/tokenized_vault/src/instructions/vaults_management/add_strategy.rs
+++ b/programs/tokenized_vault/src/instructions/vaults_management/add_strategy.rs
@@ -10,6 +10,7 @@ use crate::errors::ErrorCode;
 use crate::constants::STRATEGY_DATA_SEED;
 use crate::state::{ StrategyData, Vault};
 use crate::utils::strategy as strategy_utils;
+use crate::events::VaultAddStrategyEvent;
 
 #[derive(Accounts)]
 pub struct AddStrategy<'info> {
@@ -65,5 +66,15 @@ pub fn handle_add_strategy(ctx: Context<AddStrategy>, max_debt: u64) -> Result<(
     let vault = &mut ctx.accounts.vault.load_mut()?;
     vault.strategies_amount += 1;
     
+
+    emit!(VaultAddStrategyEvent {
+        vault_key: ctx.accounts.vault.key(),
+        strategy_key: ctx.accounts.strategy.key(),
+        current_debt: 0, 
+        max_debt,
+        last_update: Clock::get()?.unix_timestamp,
+        is_active: true,
+    });
+
     Ok(())
 }

--- a/programs/tokenized_vault/src/instructions/vaults_management/remove_strategy.rs
+++ b/programs/tokenized_vault/src/instructions/vaults_management/remove_strategy.rs
@@ -9,6 +9,8 @@ use crate::events::StrategyReportedEvent;
 use crate::state::{StrategyData, Vault};
 use crate::errors::ErrorCode;
 use crate::constants::ONE_SHARE_TOKEN;
+use crate::events::VaultRemoveStrategyEvent;
+
 #[derive(Accounts)]
 pub struct RemoveStrategy<'info> {
     #[account(mut)]
@@ -55,6 +57,7 @@ pub fn handle_remove_strategy(ctx: Context<RemoveStrategy>, strategy: Pubkey, fo
     let share_price = vault.get_share_price();
 
     emit!(StrategyReportedEvent {
+        vault_key: ctx.accounts.vault.key(),
         strategy_key: strategy,
         gain: 0,
         loss,
@@ -66,8 +69,13 @@ pub fn handle_remove_strategy(ctx: Context<RemoveStrategy>, strategy: Pubkey, fo
         timestamp: Clock::get()?.unix_timestamp,
     });
 
-
     vault.strategies_amount -= 1;
+
+    emit!(VaultRemoveStrategyEvent {
+        vault_key: ctx.accounts.vault.key(),
+        strategy_key: strategy,
+        removed_at: Clock::get()?.unix_timestamp,
+    });
 
     Ok(())
 }

--- a/programs/tokenized_vault/src/instructions/vaults_management/vault_setters.rs
+++ b/programs/tokenized_vault/src/instructions/vaults_management/vault_setters.rs
@@ -5,7 +5,16 @@ use access_control::{
     state::{UserRole, Role}
 };
 
-use crate::events::VaultUpdateDepositLimitEvent;
+use crate::events::{
+    VaultUpdateDepositLimitEvent,
+    VaultUpdateMinUserDepositEvent,
+    VaultUpdateProfitMaxUnlockTimeEvent,
+    VaultUpdateMinTotalIdleEvent,
+    VaultUpdateDirectWithdrawEnabledEvent,
+    VaultUpdateUserDepositLimitEvent,
+    VaultUpdateAccountantEvent,
+    VaultUpdateWhitelistedOnlyEvent,
+};
 use crate::errors::ErrorCode;
 use crate::state::Vault;
 
@@ -43,6 +52,7 @@ pub fn handle_set_deposit_limit(ctx: Context<SetVaultProperty>, amount: u64) -> 
     emit!(VaultUpdateDepositLimitEvent {
         vault_key: vault.key,
         new_limit: amount,
+        timestamp: Clock::get()?.unix_timestamp,
     });
 
     Ok(())
@@ -57,6 +67,12 @@ pub fn handle_set_min_user_deposit(ctx: Context<SetVaultProperty>, value: u64) -
 
     vault.min_user_deposit = value;
 
+    emit!(VaultUpdateMinUserDepositEvent {
+        vault_key: vault.key,
+        new_min_user_deposit: value,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
+
     Ok(())
 }
 
@@ -68,6 +84,12 @@ pub fn handle_set_profit_max_unlock_time(ctx: Context<SetVaultProperty>, value: 
     }
 
     vault.profit_max_unlock_time = value;
+
+    emit!(VaultUpdateProfitMaxUnlockTimeEvent {
+        vault_key: vault.key,
+        new_profit_max_unlock_time: value,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
 
     Ok(())
 }
@@ -81,6 +103,12 @@ pub fn handle_set_min_total_idle(ctx: Context<SetVaultProperty>, value: u64) -> 
 
     vault.minimum_total_idle = value;
 
+    emit!(VaultUpdateMinTotalIdleEvent {
+        vault_key: vault.key,
+        new_min_total_idle: value,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
+
     Ok(())
 }
 
@@ -88,6 +116,12 @@ pub fn handle_set_direct_withdraw_enabled(ctx: Context<SetVaultProperty>, value:
     let vault = &mut ctx.accounts.vault.load_mut()?;
 
     vault.direct_withdraw_enabled = value;
+
+    emit!(VaultUpdateDirectWithdrawEnabledEvent {
+        vault_key: vault.key,
+        new_direct_withdraw_enabled: value,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
 
     Ok(())
 }
@@ -101,6 +135,12 @@ pub fn handle_set_user_deposit_limit(ctx: Context<SetVaultProperty>, value: u64)
 
     vault.user_deposit_limit = value;
 
+    emit!(VaultUpdateUserDepositLimitEvent {
+        vault_key: vault.key,
+        new_user_deposit_limit: value,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
+
     Ok(())
 }
 
@@ -113,6 +153,12 @@ pub fn handle_set_accountant(ctx: Context<SetVaultProperty>, value: Pubkey) -> R
 
     vault.accountant = value;
 
+    emit!(VaultUpdateAccountantEvent {
+        vault_key: vault.key,
+        new_accountant: value,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
+
     Ok(())
 }
 
@@ -124,6 +170,12 @@ pub fn handle_set_whitelisted_only(ctx: Context<SetVaultProperty>, value: bool) 
     }
 
     vault.whitelisted_only = value;
+
+    emit!(VaultUpdateWhitelistedOnlyEvent {
+        vault_key: vault.key,
+        new_whitelisted_only: value,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
 
     Ok(())
 }

--- a/programs/tokenized_vault/src/instructions/withdrawal/cancel_withdrawal_request.rs
+++ b/programs/tokenized_vault/src/instructions/withdrawal/cancel_withdrawal_request.rs
@@ -58,6 +58,7 @@ pub fn handle_cancel_withdrawal_request(
         vault: ctx.accounts.withdraw_request.vault,
         user: ctx.accounts.withdraw_request.user,
         index: ctx.accounts.withdraw_request.index,
+        timestamp: Clock::get()?.unix_timestamp,
     });
 
     Ok(())

--- a/programs/tokenized_vault/src/instructions/withdrawal/fulfill_withdrawal_request.rs
+++ b/programs/tokenized_vault/src/instructions/withdrawal/fulfill_withdrawal_request.rs
@@ -163,6 +163,7 @@ pub fn handle_fulfill_withdrawal_request(ctx: Context<FulfillWithdrawalRequest>
         user: ctx.accounts.withdraw_request.user,
         amount: assets_to_transfer,
         index: ctx.accounts.withdraw_request.index,
+        timestamp: Clock::get()?.unix_timestamp,
     });
 
     Ok(())

--- a/programs/tokenized_vault/src/instructions/withdrawal/request_withdraw.rs
+++ b/programs/tokenized_vault/src/instructions/withdrawal/request_withdraw.rs
@@ -136,6 +136,7 @@ fn handle_internal<'info>(
         max_loss,
         fee_shares,
         index: ctx.accounts.withdraw_request.index,
+        timestamp: Clock::get()?.unix_timestamp,
     });
 
     Ok(())


### PR DESCRIPTION
-remove_strategy requires events so that other apps can ignore removed strategies -vault managing fns now have events with timestamp so that we can track changes over time -withdraw related methods would also have events with timestamp just like deposit instructions do -StrategyReportedEvent explicitedly emit vault_key